### PR TITLE
Add option to enable loop for stories

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import Stories from 'react-insta-stories'
 class App extends Component {
   render () {
     return (
-      <Stories 
+      <Stories
         stories={stories}
         defaultInterval={1500}
         width={432}
@@ -54,6 +54,7 @@ Property | Type | Default | Description
 `width` | Number | 360 | Width of the component in pixels
 `height` | Number | 640 | Height of the component in pixels
 `storyStyles` | Object | none | Override the default story styles mentioned below.
+`loop` | Boolean | false | The last story loop to the first one and restart the stories.
 
 
 ### Story object
@@ -65,7 +66,7 @@ Property | Description
 `duration` | Optional. Duration for which a story should persist.
 `header` | Optional. Adds a header on the top. Object with `heading`, `subheading` and `profileImage` properties.
 `seeMore` | Optional. Adds a see more icon at the bottom of the story. On clicking, opens up this component.
-`type` | Optional. To distinguish a video story. `type: 'video'` is necessary for a video story. 
+`type` | Optional. To distinguish a video story. `type: 'video'` is necessary for a video story.
 `styles` | Optional. Override the default story styles mentioned below.
 
 ### Default story styles
@@ -99,7 +100,7 @@ Show or hide the `Show More` component. Pass `true` to show and otherwise.
 
 ## Contributors
 
-This project exists thanks to all the people who contribute. 
+This project exists thanks to all the people who contribute.
 <a href="https://github.com/mohitk05/react-insta-stories/graphs/contributors"><img src="https://opencollective.com/react-insta-stories/contributors.svg?width=890&button=false" /></a>
 
 

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -12,13 +12,9 @@ export default class Container extends React.Component {
       count: 0,
       storiesDone: 0
     }
-    this.defaultInterval = 4000
+    this.defaultInterval = this.props.defaultInterval || 4000
     this.width = props.width || 360
     this.height = props.height || 640
-  }
-
-  componentDidMount() {
-    this.props.defaultInterval && (this.defaultInterval = this.props.defaultInterval)
   }
 
   pause = (action, bufferAction) => {
@@ -35,6 +31,21 @@ export default class Container extends React.Component {
   }
 
   next = () => {
+    if (this.props.loop) {
+      this.updateNextStoryIdForLoop()
+    } else {
+      this.updateNextStoryId()
+    }
+  };
+
+  updateNextStoryIdForLoop = () => {
+    this.setState({
+      currentId: (this.state.currentId + 1) % this.props.stories.length,
+      count: 0
+    })
+  }
+
+  updateNextStoryId = () => {
     if (this.state.currentId < this.props.stories.length - 1) {
       this.setState({
         currentId: this.state.currentId + 1,
@@ -65,7 +76,7 @@ export default class Container extends React.Component {
   }
 
   toggleMore = show => {
-    if(this.story) {
+    if (this.story) {
       this.story.toggleMore(show)
       return true
     } else return false
@@ -73,16 +84,16 @@ export default class Container extends React.Component {
 
   render() {
     return (
-      <div style={{...styles.container, ...{width: this.width, height: this.height}}}>
+      <div style={{ ...styles.container, ...{ width: this.width, height: this.height } }}>
         <ProgressArray
           next={this.next}
           pause={this.state.pause}
           bufferAction={this.state.bufferAction}
           videoDuration={this.state.videoDuration}
-          length={this.props.stories.map((s, i) => i)}
+          length={this.props.stories.map((_, i) => i)}
           defaultInterval={this.defaultInterval}
           currentStory={this.props.stories[this.state.currentId]}
-          progress={{id: this.state.currentId, completed: this.state.count / ((this.props.stories[this.state.currentId] && this.props.stories[this.state.currentId].duration) || this.defaultInterval)}}
+          progress={{ id: this.state.currentId, completed: this.state.count / ((this.props.stories[this.state.currentId] && this.props.stories[this.state.currentId].duration) || this.defaultInterval) }}
         />
         <Story
           ref={s => this.story = s}
@@ -98,8 +109,8 @@ export default class Container extends React.Component {
           storyContentStyles={this.props.storyContentStyles}
         />
         <div style={styles.overlay}>
-          <div style={{width: this.width / 2, zIndex: 999}} onTouchStart={this.debouncePause} onTouchEnd={e => this.mouseUp(e, 'previous')} onMouseDown={this.debouncePause} onMouseUp={(e) => this.mouseUp(e, 'previous')} />
-          <div style={{width: this.width / 2, zIndex: 999}} onTouchStart={this.debouncePause} onTouchEnd={e => this.mouseUp(e, 'next')} onMouseDown={this.debouncePause} onMouseUp={(e) => this.mouseUp(e, 'next')} />
+          <div style={{ width: this.width / 2, zIndex: 999 }} onTouchStart={this.debouncePause} onTouchEnd={e => this.mouseUp(e, 'previous')} onMouseDown={this.debouncePause} onMouseUp={(e) => this.mouseUp(e, 'previous')} />
+          <div style={{ width: this.width / 2, zIndex: 999 }} onTouchStart={this.debouncePause} onTouchEnd={e => this.mouseUp(e, 'next')} onMouseDown={this.debouncePause} onMouseUp={(e) => this.mouseUp(e, 'next')} />
         </div>
       </div>
     )
@@ -132,5 +143,6 @@ Container.propTypes = {
   height: PropTypes.number,
   loader: PropTypes.element,
   header: PropTypes.element,
-  storyContentStyles: PropTypes.object
+  storyContentStyles: PropTypes.object,
+  loop: PropTypes.bool
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,8 @@ export default class ReactInstaStories extends Component {
     this.play = this.play.bind(this)
     this.previous = this.previous.bind(this)
     this.next = this.next.bind(this)
-    this.loop = this.props.loop || false
   }
+
   componentDidMount() {
     this.props.stories.map(s => {
       let i = new Image()
@@ -66,11 +66,15 @@ export default class ReactInstaStories extends Component {
           loader={this.props.loader}
           header={this.props.header}
           storyContentStyles={this.props.storyStyles}
-          loop={this.loop}
+          loop={this.props.loop}
         />
       </div>
     )
   }
+}
+
+ReactInstaStories.defaultProps = {
+  loop: false
 }
 
 ReactInstaStories.propTypes = {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export default class ReactInstaStories extends Component {
     this.play = this.play.bind(this)
     this.previous = this.previous.bind(this)
     this.next = this.next.bind(this)
+    this.loop = this.props.loop || false
   }
   componentDidMount() {
     this.props.stories.map(s => {
@@ -20,35 +21,35 @@ export default class ReactInstaStories extends Component {
   }
 
   pause() {
-    if(this.c) {
+    if (this.c) {
       this.c.pause('pause')
       return true
     } else return false
   }
 
   play() {
-    if(this.c) {
+    if (this.c) {
       this.c.pause('play')
       return true
     } else return false
   }
 
   previous() {
-    if(this.c) {
+    if (this.c) {
       this.c.previous()
       return true
     } else return false
   }
 
   next() {
-    if(this.c) {
+    if (this.c) {
       this.c.next()
       return true
     } else return false
   }
 
   toggleSeeMore(show) {
-    if(this.c) {
+    if (this.c) {
       return this.c.toggleMore(show)
     } else return false
   }
@@ -65,6 +66,7 @@ export default class ReactInstaStories extends Component {
           loader={this.props.loader}
           header={this.props.header}
           storyContentStyles={this.props.storyStyles}
+          loop={this.loop}
         />
       </div>
     )
@@ -78,5 +80,6 @@ ReactInstaStories.propTypes = {
   height: PropTypes.number,
   loader: PropTypes.element,
   header: PropTypes.element,
-  storyStyles: PropTypes.object
+  storyStyles: PropTypes.object,
+  loop: PropTypes.bool
 }


### PR DESCRIPTION
## What is this PR?

The whole idea of this PR is to enable developers to make their stories loop

## PR changes

- Add loop default props as `false` to `ReactInstaStories`
- Add API documentation to the readme
- Set current id state to loop when it gets the last story

## Preview

<img src="https://user-images.githubusercontent.com/5835798/56777171-65b36b00-67a6-11e9-8439-d74f7280b05b.gif" width="300" />