### PR TITLE
Use custom header as a function

### DIFF
--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -142,7 +142,7 @@ Container.propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
   loader: PropTypes.element,
-  header: PropTypes.element,
+  header: PropTypes.func,
   storyContentStyles: PropTypes.object,
   loop: PropTypes.bool
 }

--- a/src/components/Story.js
+++ b/src/components/Story.js
@@ -77,7 +77,7 @@ export default class Story extends React.Component {
       <div style={{...styles.story, width: this.props.width, height: this.props.height}}>
         {this.getStoryContent()}
         {isHeader && <div style={{position: 'absolute', left: 12, top: 20, zIndex: 19}}>
-          {this.props.header ? () => this.props.header(this.props.story.header) : <Header heading={this.props.story.header.heading} subheading={this.props.story.header.subheading} profileImage={this.props.story.header.profileImage} />}
+          {this.props.header ? this.props.header(this.props.story.header) : <Header heading={this.props.story.header.heading} subheading={this.props.story.header.subheading} profileImage={this.props.story.header.profileImage} />}
         </div>}
         {!this.state.loaded && <div style={{width: this.props.width, height: this.props.height, position: 'absolute', left: 0, top: 0, background: 'rgba(0, 0, 0, 0.9)', zIndex: 9, display: 'flex', justifyContent: 'center', alignItems: 'center', color: '#ccc'}}>{this.props.loader || <div className={globalStyle.spinner} />}</div>}
         {this.props.story.seeMore &&

--- a/src/components/Story.js
+++ b/src/components/Story.js
@@ -112,7 +112,7 @@ Story.propTypes = {
   width: PropTypes.number,
   action: PropTypes.func,
   loader: PropTypes.element,
-  header: PropTypes.element,
+  header: PropTypes.func,
   playState: PropTypes.bool,
   getVideoDuration: PropTypes.func,
   bufferAction: PropTypes.bool,

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ ReactInstaStories.propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
   loader: PropTypes.element,
-  header: PropTypes.element,
+  header: PropTypes.func,
   storyStyles: PropTypes.object,
   loop: PropTypes.bool
 }


### PR DESCRIPTION
This PR makes the header proptype to be a function in order to be able to pass in the header from the story.