### PR TITLE
move onLoad callbacks for img and video tags before src definition

### DIFF
--- a/packages/react-insta-stories/src/components/Story.tsx
+++ b/packages/react-insta-stories/src/components/Story.tsx
@@ -92,14 +92,14 @@ const Story = (props: StoryProps) => {
 					? "video"
 					: "image";
 			return type === "image" ? (
-				<img style={storyContentStyles} src={source} onLoad={imageLoaded} />
+				<img onLoad={imageLoaded} style={storyContentStyles} src={source} />
 			) : type === "video" ? (
 				<video
 					ref={vid}
+					onLoadedData={videoLoaded}
 					style={storyContentStyles}
 					src={source}
 					controls={false}
-					onLoadedData={videoLoaded}
 					autoPlay
 					playsInline
 				/>


### PR DESCRIPTION
relating to: https://github.com/mohitk05/react-insta-stories/issues/44

I've got a theory that with the src defined before the load handler, the image/video loads before the before the dom is ready, in which case it won't fire the load handler. lmk what you think!