### PR TITLE
iOS bugfixes

### DIFF
--- a/src/renderers/Video.tsx
+++ b/src/renderers/Video.tsx
@@ -19,6 +19,7 @@ export const renderer: Renderer = ({ story, action, isPaused, config, messageHan
     React.useEffect(() => {
         if (vid.current) {
             if (isPaused) {
+                action("pause", true);
                 vid.current.pause();
             } else {
                 vid.current.play().catch(() => { });
@@ -55,6 +56,7 @@ export const renderer: Renderer = ({ story, action, isPaused, config, messageHan
                     style={computedStyles}
                     src={story.url}
                     controls={false}
+                    onLoadStart={onWaiting}
                     onLoadedData={videoLoaded}
                     playsInline
                     onWaiting={onWaiting}


### PR DESCRIPTION
Fix for #158

- `ProgressArray` handles variable frame rates using the `timestamp` argument for `requestAnimationFrame`
- Default `Video` uses `onLoadStart` event to prevent progress for video story elements being started too early

@mohitk05 let me know if you think this needs any more changes.