### PR TITLE
Higher z-index for progress bar

### DIFF
--- a/src/components/ProgressArray.tsx
+++ b/src/components/ProgressArray.tsx
@@ -88,7 +88,7 @@ const styles = {
         padding: 5,
         paddingTop: 7,
         alignSelf: 'center',
-        zIndex: 99,
+        zIndex: 1001,
         filter: 'drop-shadow(0 1px 8px #222)'
     }
 }


### PR DESCRIPTION
In some projects, a video that needs to be clicked in order to be played and that also is viewed in full height is blocking the top progress bar.
In order to show the progress bar, a higher z-index is required.
Maybe the progress bar should receive props as well.
![image](https://user-images.githubusercontent.com/76150116/167292744-ea38f64b-9d81-40b6-ba95-d463f6caeea9.png)
