### PR TITLE
Prefer user-provided styles (in storyContainerStyles) over default styles (styles.container)

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -117,7 +117,7 @@ export default function () {
     }
 
     return (
-        <div style={{ ...storyContainerStyles, ...styles.container, ...{ width, height } }}>
+        <div style={{ ...styles.container, ...storyContainerStyles, ...{ width, height } }}>
             <ProgressContext.Provider value={{
                 bufferAction: bufferAction,
                 videoDuration: videoDuration,


### PR DESCRIPTION
Just swapped them so that user-provided styles come later. This way, the user's provided Style fields override the default ones.

e.g. if user supplies the following storyContainerStyles:
```
    storyContainerStyles={{
             background: "red"
    }}
```

Then it overrides the default which is in styles.container:
```
const styles = {
    container: {
        display: 'flex',
        flexDirection: 'column',
        background: '#111',          <-------- This one
        position: 'relative'
    },
    overlay: {
        position: 'absolute',
        height: 'inherit',
        width: 'inherit',
        display: 'flex'
    }
} 
```

Might solve #215 . If it works, the same can be done for storyStyles.