### PR TITLE
onAllStoriesEnd when finishing the stories on click + Classes for invisible next/prev buttons

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -71,6 +71,7 @@ export default function () {
     }
 
     const previous = () => {
+        console.log(currentIndex);
         setCurrentIdWrapper(prev => prev > 0 ? prev - 1 : prev)
     }
 


### PR DESCRIPTION
This PR is adding the onAllStoriesEnd to the case when we're not looping through the stories and when the last story is shown and the user clicked "next", in addition to the original onAllStoriesEnd callback use