### PR TITLE
fix: can't go previous stories when stories has ended

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -80,7 +80,6 @@ export default function () {
 
   const setCurrentIdWrapper = (callback) => {
     setCurrentId(callback);
-    toggleState("pause", true);
   };
 
   const previous = () => {


### PR DESCRIPTION
`Reproduce`: 

trying with this link `https://stackblitz.com/edit/react-insta-stories-mr9yer?file=src%2FApp.js` with the latest version 
- when stories have finished, then when I want to go to previous stories, the stories won't back to the previous.

and look at the code, i found this on `components/Container.tsx`

my suggestion in func 

```tsx
  const setCurrentIdWrapper = (callback) => {
    setCurrentId(callback);
    toggleState("pause", true);
  };
```
and

```tsx
  const mouseUp =
    (type: string) => (e: React.MouseEvent | React.TouchEvent) => {
      e.preventDefault();
      mousedownId.current && clearTimeout(mousedownId.current);
      if (pause) {
        toggleState("play");
      } else {
        type === "next" ? next() : previous();
      }
    };
```

when i try to modify the mouseUp func, the problem is if i hold for a pause in the next area, when i up the mouse, function next() will triggered, and otherwise

so i choose remove `toggleState("pause", true);` on `setCurrentIdWrapper ` func instead

