### PR TITLE
fix: onNext being called when story ends (first method)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-insta-stories",
-	"version": "2.6.0",
+	"version": "2.6.1",
 	"description": "A React component for Instagram like stories",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -71,7 +71,7 @@ export default function () {
     if (e.key === "ArrowLeft") {
       previous();
     } else if (e.key === "ArrowRight") {
-      next(true);
+      next({ isSkippedByUser: true });
     }
   };
 
@@ -92,8 +92,8 @@ export default function () {
     setCurrentIdWrapper((prev) => (prev > 0 ? prev - 1 : prev));
   };
 
-  const next = (isSkippedByUser?: boolean) => {
-    if (onNext != undefined && isSkippedByUser) {
+  const next = (options?: { isSkippedByUser?: boolean }) => {
+    if (onNext != undefined && options?.isSkippedByUser) {
       onNext();
     }
     // Check if component is mounted - for issue #130 (https://github.com/mohitk05/react-insta-stories/issues/130)
@@ -137,7 +137,7 @@ export default function () {
       if (pause) {
         toggleState("play");
       } else {
-        type === "next" ? next(true) : previous();
+        type === "next" ? next({ isSkippedByUser: true }) : previous();
       }
     };
 

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -69,8 +69,14 @@ export default function () {
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "ArrowLeft") {
+      if(onPrevious != undefined){
+        onPrevious();
+      }
       previous();
     } else if (e.key === "ArrowRight") {
+      if(onNext != undefined){
+        onNext();
+      }
       next();
     }
   };
@@ -86,16 +92,10 @@ export default function () {
   };
 
   const previous = () => {
-    if(onPrevious != undefined){
-      onPrevious();
-    }
     setCurrentIdWrapper((prev) => (prev > 0 ? prev - 1 : prev));
   };
 
   const next = () => {
-    if(onNext != undefined){
-      onNext();
-    }
     // Check if component is mounted - for issue #130 (https://github.com/mohitk05/react-insta-stories/issues/130)
     if (isMounted()) {
       if (loop) {
@@ -137,7 +137,17 @@ export default function () {
       if (pause) {
         toggleState("play");
       } else {
-        type === "next" ? next() : previous();
+        if(type === "next"){
+          if(onNext != undefined){
+            onNext();
+          }
+          next();
+        }else{
+          if(onPrevious != undefined){
+            onPrevious();
+          }
+          previous();
+        }
       }
     };
 

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -69,15 +69,9 @@ export default function () {
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "ArrowLeft") {
-      if(onPrevious != undefined){
-        onPrevious();
-      }
       previous();
     } else if (e.key === "ArrowRight") {
-      if(onNext != undefined){
-        onNext();
-      }
-      next();
+      next(true);
     }
   };
 
@@ -92,10 +86,16 @@ export default function () {
   };
 
   const previous = () => {
+    if (onPrevious != undefined) {
+      onPrevious();
+    }
     setCurrentIdWrapper((prev) => (prev > 0 ? prev - 1 : prev));
   };
 
-  const next = () => {
+  const next = (isSkippedByUser?: boolean) => {
+    if (onNext != undefined && isSkippedByUser) {
+      onNext();
+    }
     // Check if component is mounted - for issue #130 (https://github.com/mohitk05/react-insta-stories/issues/130)
     if (isMounted()) {
       if (loop) {
@@ -137,17 +137,7 @@ export default function () {
       if (pause) {
         toggleState("play");
       } else {
-        if(type === "next"){
-          if(onNext != undefined){
-            onNext();
-          }
-          next();
-        }else{
-          if(onPrevious != undefined){
-            onPrevious();
-          }
-          previous();
-        }
+        type === "next" ? next(true) : previous();
       }
     };
 


### PR DESCRIPTION
As SE
I want `onNext` callback being called only after user input
so that I can correctly use the callbacks


**Steps to reproduce** 

- open the demo and let a story complete
- the console shows that the onNext callback has been called

**Note**

There are two ways of solving this, this is the first method. It doesn't cover the `onPrevious` case, since there's no use case yet.


