### PR TITLE
 fix: onNext being called when story ends (second method)

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -69,8 +69,14 @@ export default function () {
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "ArrowLeft") {
+      if(onPrevious != undefined){
+        onPrevious();
+      }
       previous();
     } else if (e.key === "ArrowRight") {
+      if(onNext != undefined){
+        onNext();
+      }
       next();
     }
   };
@@ -86,16 +92,10 @@ export default function () {
   };
 
   const previous = () => {
-    if(onPrevious != undefined){
-      onPrevious();
-    }
     setCurrentIdWrapper((prev) => (prev > 0 ? prev - 1 : prev));
   };
 
   const next = () => {
-    if(onNext != undefined){
-      onNext();
-    }
     // Check if component is mounted - for issue #130 (https://github.com/mohitk05/react-insta-stories/issues/130)
     if (isMounted()) {
       if (loop) {
@@ -137,7 +137,17 @@ export default function () {
       if (pause) {
         toggleState("play");
       } else {
-        type === "next" ? next() : previous();
+        if(type === "next"){
+          if(onNext != undefined){
+            onNext();
+          }
+          next();
+        }else{
+          if(onPrevious != undefined){
+            onPrevious();
+          }
+          previous();
+        }
       }
     };
 


### PR DESCRIPTION
As SE
I want `onNext` and `onPrevious` callbacks being called only after user input
so that I can correctly use the callbacks


Steps to reproduce: 

- open the demo and let a story complete
- the console shows that the onNext callback has been called

Note

There are two ways of solving this, this  is the second method
This solution implements the check also for the `onPrevious` although there's no current use case.


