### PR TITLE
fix: Replace old prototype-based "defaultProps" with JS default parameters

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,5 @@
   "trailingComma": "es5",
   "tabWidth": 2,
   "semi": false,
-  "singleQuote": true,
+  "singleQuote": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 120,
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "react-insta-stories",
-	"version": "2.5.9",
+	"version": "2.6.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "react-insta-stories",
-			"version": "2.5.9",
+			"version": "2.6.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@babel/core": "^7.5.5",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,78 +2,83 @@ import React, { useEffect, useState } from 'react'
 import { ReactInstaStoriesProps, GlobalCtx, Story, Tester, Renderer } from './interfaces'
 import Container from './components/Container'
 import GlobalContext from './context/Global'
-import StoriesContext from './context/Stories';
+import StoriesContext from './context/Stories'
 import { getRenderer } from './util/renderers'
-import { renderers as defaultRenderers } from './renderers/index';
+import { renderers as defaultRenderers } from './renderers/index'
 import withHeader from './renderers/wrappers/withHeader'
 import withSeeMore from './renderers/wrappers/withSeeMore'
 
-const ReactInstaStories = function (props: ReactInstaStoriesProps) {
-    let renderers = props.renderers ? props.renderers.concat(defaultRenderers) : defaultRenderers;
-    let context: GlobalCtx = {
-        width: props.width,
-        height: props.height,
-        loader: props.loader,
-        header: props.header,
-        storyContainerStyles: props.storyContainerStyles,
-        storyInnerContainerStyles: props.storyInnerContainerStyles,
-        storyStyles: props.storyStyles,
-        progressContainerStyles: props.progressContainerStyles,
-        progressWrapperStyles: props.progressWrapperStyles,
-        progressStyles: props.progressStyles,
-        loop: props.loop,
-        defaultInterval: props.defaultInterval,
-        isPaused: props.isPaused,
-        currentIndex: props.currentIndex,
-        onStoryStart: props.onStoryStart,
-        onStoryEnd: props.onStoryEnd,
-        onAllStoriesEnd: props.onAllStoriesEnd,
-        onNext: props.onNext,
-        onPrevious: props.onPrevious,
-        keyboardNavigation: props.keyboardNavigation,
-        preventDefault: props.preventDefault,
-        preloadCount: props.preloadCount,
-    }
-    const [stories, setStories] = useState<{ stories: Story[] }>({ stories: generateStories(props.stories, renderers) });
+const ReactInstaStories = ({
+  width = 360,
+  height = 640,
+  defaultInterval = 4000,
+  preloadCount = 1,
+  ...props
+}: ReactInstaStoriesProps) => {
+  const renderers: ReactInstaStoriesProps['renderers'] = props.renderers
+    ? props.renderers.concat(defaultRenderers)
+    : defaultRenderers
 
+  const context: GlobalCtx = {
+    width: width,
+    height: height,
+    loader: props.loader,
+    header: props.header,
+    storyContainerStyles: props.storyContainerStyles,
+    storyInnerContainerStyles: props.storyInnerContainerStyles,
+    storyStyles: props.storyStyles,
+    progressContainerStyles: props.progressContainerStyles,
+    progressWrapperStyles: props.progressWrapperStyles,
+    progressStyles: props.progressStyles,
+    loop: props.loop,
+    defaultInterval: defaultInterval,
+    isPaused: props.isPaused,
+    currentIndex: props.currentIndex,
+    onStoryStart: props.onStoryStart,
+    onStoryEnd: props.onStoryEnd,
+    onAllStoriesEnd: props.onAllStoriesEnd,
+    onNext: props.onNext,
+    onPrevious: props.onPrevious,
+    keyboardNavigation: props.keyboardNavigation,
+    preventDefault: props.preventDefault,
+    preloadCount: preloadCount,
+  }
 
-    useEffect(() => {
-        setStories({ stories: generateStories(props.stories, renderers) });
-    }, [props.stories, props.renderers]);
+  const [stories, setStories] = useState<{ stories: Story[] }>({
+    stories: generateStories(props.stories, renderers),
+  })
 
-    return <GlobalContext.Provider value={context}>
-        <StoriesContext.Provider value={stories}>
-            <Container />
-        </StoriesContext.Provider>
+  useEffect(() => {
+    setStories({ stories: generateStories(props.stories, renderers) })
+  }, [props.stories, props.renderers])
+
+  return (
+    <GlobalContext.Provider value={context}>
+      <StoriesContext.Provider value={stories}>
+        <Container />
+      </StoriesContext.Provider>
     </GlobalContext.Provider>
+  )
+}
+const generateStories = (stories: Story[], renderers: { renderer: Renderer; tester: Tester }[]) => {
+  return stories.map((s) => {
+    let story: Story = {}
+
+    if (typeof s === 'string') {
+      story.url = s
+      story.type = 'image'
+    } else if (typeof s === 'object') {
+      story = Object.assign(story, s)
+    }
+
+    let renderer = getRenderer(story, renderers)
+    story.originalContent = story.content
+    story.content = renderer
+    return story
+  })
 }
 
-const generateStories = (stories: Story[], renderers: { renderer: Renderer, tester: Tester }[]) => {
-    return stories.map(s => {
-        let story: Story = {};
-
-        if (typeof s === 'string') {
-            story.url = s;
-            story.type = 'image';
-        } else if (typeof s === 'object') {
-            story = Object.assign(story, s);
-        }
-
-        let renderer = getRenderer(story, renderers);
-        story.originalContent = story.content;
-        story.content = renderer;
-        return story
-    })
-};
-
-ReactInstaStories.defaultProps = {
-    width: 360,
-    height: 640,
-    defaultInterval: 4000,
-    preloadCount: 1,
-}
-
-export const WithHeader = withHeader;
-export const WithSeeMore = withSeeMore;
+export const WithHeader = withHeader
+export const WithSeeMore = withSeeMore
 
 export default ReactInstaStories


### PR DESCRIPTION
## Proposed Changes

In the `index.tsx` file, the `ReactInstaStories` component currently uses `ReactInstaStories.defaultProps` to define default props. This approach triggers a `console.error` warning, as it will be deprecated in future major releases. This PR addresses the issue by replacing the deprecated approach with JavaScript default parameters.

### Context

The existing code generates a `console.error` warning due to the deprecated usage of `ReactInstaStories.defaultProps`. This warning will be removed in upcoming major releases. To ensure code maintainability and align with modern best practices, the code is updated in order to use JavaScript default parameters.

### Checklist

- [x] Replaced deprecated `ReactInstaStories.defaultProps`.
- [x] Implemented JavaScript default parameters for default prop values.

### Screenshots

<img width="914" alt="image" src="https://github.com/mohitk05/react-insta-stories/assets/48724574/37aed609-27d5-4056-8da1-579d1e6a4142">
