### PR TITLE
make header above next/previous so its clickable

### DIFF
--- a/src/renderers/wrappers/withHeader.tsx
+++ b/src/renderers/wrappers/withHeader.tsx
@@ -10,7 +10,7 @@ const withHeader: React.FC<React.PropsWithChildren<{
     <>
       {children}
       {story.header && (
-        <div style={{ position: "absolute", left: 12, top: 20, zIndex: 19 }}>
+        <div style={{ position: "absolute", left: 12, top: 20, zIndex: 1000 }}>
           {typeof story === "object" ? (
             globalHeader ? (
               globalHeader(story.header)


### PR DESCRIPTION
I make this change, so its possible to create custom header component that is clickable by changing the z-index of header wrapper